### PR TITLE
修复当思源笔记部署在其他设备时，请求的地址不正确的问题

### DIFF
--- a/src/utils/siyuan_client.ts
+++ b/src/utils/siyuan_client.ts
@@ -3,12 +3,6 @@ import { Client } from '@siyuan-community/siyuan-sdk'
 /* 初始化客户端 (默认使用 Axios 发起 XHR 请求) */
 export const siyuanClient = new Client({
   /**
-   * (可选) 思源内核服务地址
-   * @default: document.baseURI
-   */
-  baseURL: 'http://localhost:6806/',
-
-  /**
    * (可选) 思源内核服务 token
    * @default: <空>
    */


### PR DESCRIPTION
![Image](https://github.com/user-attachments/assets/2d22e884-4d0c-40b0-ba30-2c85a26deb28)
当思源笔记部署在其他设备时，没有正确请求目标地址而是请求了localhost，
问题在于siyuan_client.ts文件中使用了硬编码的baseURL，应当移除